### PR TITLE
Conditionally run jobs

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -3,12 +3,23 @@ name: create-pr
 
 on:
   workflow_dispatch:
+    inputs:
+      run_for:
+        type: choice
+        description: What to update
+        options:
+        - infra-deployments
+        - build-definitions
+        - both
   schedule:
     # At 09:00 UTC on Tuesday
     - cron: '0 9 * * 2'
 
 jobs:
   create-infra-deployments-pr:
+    # also run by default
+    if: >
+      github.event.inputs.chosen-os == 'infra-deployments' || github.event.inputs.chosen-os == 'both' || github.event.inputs.chosen-os == ''
     runs-on: ubuntu-latest
 
     steps:
@@ -85,6 +96,8 @@ jobs:
       working-directory: infra-deployments-ci
 
   create-build-definitions-pr:
+    if: >
+      github.event.inputs.chosen-os == 'build-definitions' || github.event.inputs.chosen-os == 'both'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Jobs now run conditionally based on the input provided when manually run. By default the `infra-deployments` should run, and `build-definitions` are optional; there is also an option `both` to run both updates in the same workflow run.