### PR TITLE
chore(ci): remove `update ec-policies` step

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -51,17 +51,6 @@ jobs:
       run: ./hack/update-infra-deployments.sh ../infra-deployments
       working-directory: ec-cli
 
-    - name: Checkout ec-policies
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: enterprise-contract/ec-policies
-        ref: main
-        path: ec-policies
-
-    - name: Update ec-policies
-      run: ./hack/update-infra-deployments.sh ../infra-deployments
-      working-directory: ec-policies
-
     - name: Checkout enterprise-contract-controller
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
This commit removes the update-ec-policies step from the `create-infra-deployments-pr` job as a byproduct of EC-1161.

Ref: EC-1283