### PR TITLE
chore: update references to config repo

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -65,7 +65,7 @@ jobs:
     - name: Checkout ec-config
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        repository: enterprise-contract/config
+        repository: conforma/config
         ref: main
         path: ec-config
 


### PR DESCRIPTION
This commit updates references to the config repo from `enterprise-contract/config` to `conforma/config`.

Ref: EC-1115