### PR TITLE
Allow for running each job separately

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -3,6 +3,15 @@ name: konflux-policy
 
 on:
   workflow_dispatch:
+    inputs:
+      run_tag:
+        description: 'Tag tested images'
+        type: boolean
+        default: true
+      run_tekton_catalog:
+        description: 'Sync task definitions to tekton-catalog'
+        type: boolean
+        default: true
   # Disabled as part of konflux release freeze and ITN-2026-00051
   # schedule:
   #   # At 08:30 UTC on Tuesday
@@ -47,6 +56,7 @@ jobs:
       run: make acceptance
 
   tag:
+    if: inputs.run_tag != false
     runs-on: ubuntu-latest
     needs: [acceptance-tests]
 
@@ -103,8 +113,9 @@ jobs:
         done
 
   tekton-catalog-release:
+    if: inputs.run_tekton_catalog != false
     runs-on: ubuntu-latest
-    needs: [acceptance-tests, tag]
+    needs: [acceptance-tests]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Before we had to release everything at once. This separates the image tagging with the branch updates.

https://redhat.atlassian.net/browse/EC-1692