### PR TITLE
Update POLICY_BUNDLE_DIGEST in tekton-task bundle and catalog

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -166,31 +166,7 @@ jobs:
         ./hack/extract-all-bundle-tasks.sh "$BUNDLE" /tmp/catalog-tasks
 
     - name: Update policy bundle digest in task definitions
-      run: |
-        set -euo pipefail
-
-        NEW_DIGEST=$(crane digest quay.io/conforma/release-policy:konflux)
-        echo "Release policy digest: ${NEW_DIGEST}"
-
-        TASK_FILES=$(grep -rl 'POLICY_BUNDLE_DIGEST' /tmp/catalog-tasks/tasks/ || true)
-        if [ -z "$TASK_FILES" ]; then
-          echo "ERROR: No task files contain POLICY_BUNDLE_DIGEST"
-          exit 1
-        fi
-
-        for f in $TASK_FILES; do
-          OLD_DIGEST=$(yq eval '.spec.params[] | select(.name == "POLICY_BUNDLE_DIGEST") | .default' "$f")
-          if [ -z "$OLD_DIGEST" ] || [ "$OLD_DIGEST" = "null" ]; then
-            echo "Warning: could not extract current digest from $f, skipping"
-            continue
-          fi
-          if [ "$OLD_DIGEST" = "$NEW_DIGEST" ]; then
-            echo "Already up to date in $f"
-            continue
-          fi
-          yq eval '(.spec.params[] | select(.name == "POLICY_BUNDLE_DIGEST") | .default) = "'"${NEW_DIGEST}"'"' -i "$f"
-          echo "Updated $f: ${OLD_DIGEST} → ${NEW_DIGEST}"
-        done
+      run: ./hack/update-policy-digest.sh /tmp/catalog-tasks/tasks/
 
     - name: Upload task definitions
       uses: actions/upload-artifact@v4

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -180,8 +180,8 @@ jobs:
         fi
 
         for f in $TASK_FILES; do
-          OLD_DIGEST=$(sed -n '/- name: POLICY_BUNDLE_DIGEST$/,/- name: /{s/.*default: "\(sha256:[a-f0-9]*\)".*/\1/p;}' "$f")
-          if [ -z "$OLD_DIGEST" ]; then
+          OLD_DIGEST=$(yq eval '.spec.params[] | select(.name == "POLICY_BUNDLE_DIGEST") | .default' "$f")
+          if [ -z "$OLD_DIGEST" ] || [ "$OLD_DIGEST" = "null" ]; then
             echo "Warning: could not extract current digest from $f, skipping"
             continue
           fi
@@ -189,7 +189,7 @@ jobs:
             echo "Already up to date in $f"
             continue
           fi
-          sed -i "s|${OLD_DIGEST}|${NEW_DIGEST}|g" "$f"
+          yq eval '(.spec.params[] | select(.name == "POLICY_BUNDLE_DIGEST") | .default) = "'"${NEW_DIGEST}"'"' -i "$f"
           echo "Updated $f: ${OLD_DIGEST} → ${NEW_DIGEST}"
         done
 

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -5,7 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       run_tag:
-        description: 'Tag tested images'
+        description: 'Tag tested images as :konflux'
+        type: boolean
+        default: true
+      run_tekton_task_bundle:
+        description: 'Rebuild tekton-task bundle with updated policy digest'
         type: boolean
         default: true
       run_tekton_catalog:
@@ -125,8 +129,8 @@ jobs:
           echo "Image digest: $(cat image.digest)"
         done
 
-  tekton-catalog-release:
-    if: ${{ !cancelled() && !failure() && inputs.run_tekton_catalog != false }}
+  tekton-task-bundle:
+    if: ${{ !cancelled() && !failure() && inputs.run_tekton_task_bundle != false }}
     runs-on: ubuntu-latest
     needs: [acceptance-tests, tag]
 
@@ -204,6 +208,31 @@ jobs:
 
         tkn bundle push quay.io/conforma/tekton-task:konflux "${TASK_FILES[@]}"
 
+  tekton-catalog:
+    if: ${{ !cancelled() && !failure() && inputs.run_tekton_catalog != false }}
+    runs-on: ubuntu-latest
+    needs: [acceptance-tests, tekton-task-bundle]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install crane
+      uses: imjasonh/setup-crane@v0.4
+
+    - name: Install yq
+      uses: mikefarah/yq@v4
+
+    - name: Log in to quay.io/conforma
+      env:
+        CONFORMA_USER: ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }}
+        CONFORMA_PASS: ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }}
+      run: crane auth login quay.io -u "$CONFORMA_USER" -p "$CONFORMA_PASS"
+
+    - name: Extract tasks from tekton-task:konflux bundle
+      run: |
+        set -euo pipefail
+        ./hack/extract-all-bundle-tasks.sh quay.io/conforma/tekton-task:konflux /tmp/catalog-tasks
+
     - name: Generate token
       id: app-token
       uses: actions/create-github-app-token@v1
@@ -227,12 +256,10 @@ jobs:
 
         cd tekton-catalog
 
-        # Copy extracted tasks into the catalog
         cp -r /tmp/catalog-tasks/tasks/* tasks/
 
         git add tasks/
 
-        # Check if there are staged changes
         if git diff --cached --quiet; then
           echo "No changes to task definitions"
           exit 0

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -115,7 +115,9 @@ jobs:
       run: |
         set -euo pipefail
 
-        echo "$BUNDLE_DIGESTS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r url pinned; do
+        echo "$BUNDLE_DIGESTS" | jq -r '
+          to_entries[] | select(.key | test("tekton-task") | not) |
+          "\(.key)|\(.value)"' | while IFS='|' read -r url pinned; do
           repo="${url%:*}"
           echo "Tagging ${pinned} → ${repo}:konflux"
           skopeo copy --all --digestfile image.digest \
@@ -124,9 +126,9 @@ jobs:
         done
 
   tekton-catalog-release:
-    if: inputs.run_tekton_catalog != false
+    if: ${{ !cancelled() && !failure() && inputs.run_tekton_catalog != false }}
     runs-on: ubuntu-latest
-    needs: [acceptance-tests]
+    needs: [acceptance-tests, tag]
 
     steps:
     - uses: actions/checkout@v4
@@ -137,10 +139,70 @@ jobs:
     - name: Install yq
       uses: mikefarah/yq@v4
 
-    - name: Extract tested tasks from pinned bundle digests
+    - name: Install tkn
+      uses: tektoncd/actions/setup-tektoncd-cli@v1
+      with:
+        version: latest
+
+    - name: Log in to quay.io/conforma
+      env:
+        CONFORMA_USER: ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }}
+        CONFORMA_PASS: ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }}
+      run: crane auth login quay.io -u "$CONFORMA_USER" -p "$CONFORMA_PASS"
+
+    - name: Extract all tasks from tested bundle
       env:
         BUNDLE_DIGESTS: ${{ needs.acceptance-tests.outputs.bundle-digests }}
-      run: ./hack/extract-tested-tasks.sh /tmp/catalog-tasks
+      run: |
+        set -euo pipefail
+
+        BUNDLE=$(echo "$BUNDLE_DIGESTS" | jq -r '
+          to_entries[] | select(.key | test("tekton-task")) | .value')
+
+        if [ -z "$BUNDLE" ]; then
+          echo "ERROR: No tekton-task bundle found in BUNDLE_DIGESTS"
+          exit 1
+        fi
+
+        ./hack/extract-all-bundle-tasks.sh "$BUNDLE" /tmp/catalog-tasks
+
+    - name: Update policy bundle digest in task definitions
+      run: |
+        set -euo pipefail
+
+        NEW_DIGEST=$(crane digest quay.io/conforma/release-policy:konflux)
+        echo "Release policy digest: ${NEW_DIGEST}"
+
+        TASK_FILES=$(grep -rl 'POLICY_BUNDLE_DIGEST' /tmp/catalog-tasks/tasks/ || true)
+        if [ -z "$TASK_FILES" ]; then
+          echo "No task files contain POLICY_BUNDLE_DIGEST, nothing to update"
+          exit 0
+        fi
+
+        for f in $TASK_FILES; do
+          OLD_DIGEST=$(sed -n '/- name: POLICY_BUNDLE_DIGEST$/,/- name: /{s/.*default: "\(sha256:[a-f0-9]*\)".*/\1/p;}' "$f")
+          if [ -z "$OLD_DIGEST" ]; then
+            echo "Warning: could not extract current digest from $f, skipping"
+            continue
+          fi
+          if [ "$OLD_DIGEST" = "$NEW_DIGEST" ]; then
+            echo "Already up to date in $f"
+            continue
+          fi
+          sed -i "s|${OLD_DIGEST}|${NEW_DIGEST}|g" "$f"
+          echo "Updated $f: ${OLD_DIGEST} → ${NEW_DIGEST}"
+        done
+
+    - name: Push updated tekton-task bundle
+      run: |
+        set -euo pipefail
+
+        TASK_FILES=()
+        while IFS= read -r f; do
+          TASK_FILES+=("-f" "$f")
+        done < <(find /tmp/catalog-tasks/tasks -name '*.yaml' -type f)
+
+        tkn bundle push quay.io/conforma/tekton-task:konflux "${TASK_FILES[@]}"
 
     - name: Generate token
       id: app-token

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -175,8 +175,8 @@ jobs:
 
         TASK_FILES=$(grep -rl 'POLICY_BUNDLE_DIGEST' /tmp/catalog-tasks/tasks/ || true)
         if [ -z "$TASK_FILES" ]; then
-          echo "No task files contain POLICY_BUNDLE_DIGEST, nothing to update"
-          exit 0
+          echo "ERROR: No task files contain POLICY_BUNDLE_DIGEST"
+          exit 1
         fi
 
         for f in $TASK_FILES; do

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -129,8 +129,8 @@ jobs:
           echo "Image digest: $(cat image.digest)"
         done
 
-  tekton-task-bundle:
-    if: ${{ !cancelled() && !failure() && inputs.run_tekton_task_bundle != false }}
+  update-task-definitions:
+    if: ${{ !cancelled() && !failure() && (inputs.run_tekton_task_bundle != false || inputs.run_tekton_catalog != false) }}
     runs-on: ubuntu-latest
     needs: [acceptance-tests, tag]
 
@@ -142,11 +142,6 @@ jobs:
 
     - name: Install yq
       uses: mikefarah/yq@v4
-
-    - name: Install tkn
-      uses: tektoncd/actions/setup-tektoncd-cli@v1
-      with:
-        version: latest
 
     - name: Log in to quay.io/conforma
       env:
@@ -197,7 +192,39 @@ jobs:
           echo "Updated $f: ${OLD_DIGEST} → ${NEW_DIGEST}"
         done
 
-    - name: Push updated tekton-task bundle
+    - name: Upload task definitions
+      uses: actions/upload-artifact@v4
+      with:
+        name: task-definitions
+        path: /tmp/catalog-tasks/tasks/
+
+  tekton-task-bundle:
+    if: ${{ needs.update-task-definitions.result == 'success' && inputs.run_tekton_task_bundle != false }}
+    runs-on: ubuntu-latest
+    needs: [update-task-definitions]
+
+    steps:
+    - name: Install crane
+      uses: imjasonh/setup-crane@v0.4
+
+    - name: Install tkn
+      uses: tektoncd/actions/setup-tektoncd-cli@v1
+      with:
+        version: latest
+
+    - name: Log in to quay.io/conforma
+      env:
+        CONFORMA_USER: ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }}
+        CONFORMA_PASS: ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }}
+      run: crane auth login quay.io -u "$CONFORMA_USER" -p "$CONFORMA_PASS"
+
+    - name: Download task definitions
+      uses: actions/download-artifact@v4
+      with:
+        name: task-definitions
+        path: /tmp/catalog-tasks/tasks/
+
+    - name: Push tekton-task bundle
       run: |
         set -euo pipefail
 
@@ -209,29 +236,16 @@ jobs:
         tkn bundle push quay.io/conforma/tekton-task:konflux "${TASK_FILES[@]}"
 
   tekton-catalog:
-    if: ${{ !cancelled() && !failure() && inputs.run_tekton_catalog != false }}
+    if: ${{ needs.update-task-definitions.result == 'success' && inputs.run_tekton_catalog != false }}
     runs-on: ubuntu-latest
-    needs: [acceptance-tests, tekton-task-bundle]
+    needs: [update-task-definitions]
 
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Install crane
-      uses: imjasonh/setup-crane@v0.4
-
-    - name: Install yq
-      uses: mikefarah/yq@v4
-
-    - name: Log in to quay.io/conforma
-      env:
-        CONFORMA_USER: ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }}
-        CONFORMA_PASS: ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }}
-      run: crane auth login quay.io -u "$CONFORMA_USER" -p "$CONFORMA_PASS"
-
-    - name: Extract tasks from tekton-task:konflux bundle
-      run: |
-        set -euo pipefail
-        ./hack/extract-all-bundle-tasks.sh quay.io/conforma/tekton-task:konflux /tmp/catalog-tasks
+    - name: Download task definitions
+      uses: actions/download-artifact@v4
+      with:
+        name: task-definitions
+        path: /tmp/catalog-tasks/tasks/
 
     - name: Generate token
       id: app-token

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,2 @@
+--shell bash
+--require spec_helper

--- a/hack/extract-all-bundle-tasks.sh
+++ b/hack/extract-all-bundle-tasks.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Extracts all task definitions from a Tekton bundle and arranges them in
+# the catalog directory layout: tasks/<task-name>/<version>/<task-name>.yaml
+#
+# Unlike extract-tested-tasks.sh, this script extracts every task in the
+# bundle, not just those referenced in acceptance pipelines.
+#
+# Usage:
+#   extract-all-bundle-tasks.sh <bundle-ref> <output-dir>
+#
+# Arguments:
+#   bundle-ref  - OCI reference for the Tekton bundle (tag or digest)
+#   output-dir  - Directory to write extracted tasks into
+
+set -euo pipefail
+
+BUNDLE="${1:?Usage: extract-all-bundle-tasks.sh <bundle-ref> <output-dir>}"
+OUTPUT_DIR="${2:?Usage: extract-all-bundle-tasks.sh <bundle-ref> <output-dir>}"
+
+REPO="${BUNDLE%@*}"
+REPO="${REPO%:*}"
+
+MANIFEST=$(crane manifest "$BUNDLE")
+
+TASK_LAYERS=$(echo "$MANIFEST" | jq -c '
+    .layers[] | select(.annotations["dev.tekton.image.kind"] == "task")')
+
+if [ -z "$TASK_LAYERS" ]; then
+    echo "ERROR: No task layers found in bundle ${BUNDLE}"
+    exit 1
+fi
+
+COUNT=0
+while IFS= read -r layer; do
+    [ -z "$layer" ] && continue
+
+    DIGEST=$(echo "$layer" | jq -r '.digest')
+    NAME=$(echo "$layer" | jq -r '.annotations["dev.tekton.image.name"]')
+
+    echo "Extracting task: $NAME"
+
+    TASK_YAML=$(crane blob "${REPO}@${DIGEST}" | gunzip | tar -xO)
+
+    VERSION=$(echo "$TASK_YAML" | yq eval '.metadata.labels["app.kubernetes.io/version"]' -)
+    if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+        echo "ERROR: Task $NAME is missing the app.kubernetes.io/version label"
+        exit 1
+    fi
+
+    TASK_DIR="${OUTPUT_DIR}/tasks/${NAME}/${VERSION}"
+    mkdir -p "$TASK_DIR"
+    echo "$TASK_YAML" | yq eval '.' -P - > "${TASK_DIR}/${NAME}.yaml"
+
+    echo "  Written to ${TASK_DIR}/${NAME}.yaml"
+    COUNT=$((COUNT + 1))
+done <<< "$TASK_LAYERS"
+
+echo ""
+echo "Done. Extracted ${COUNT} task(s) to ${OUTPUT_DIR}"

--- a/hack/update-policy-digest.sh
+++ b/hack/update-policy-digest.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Updates the POLICY_BUNDLE_DIGEST default value in Tekton task definitions
+# to match the current digest of a policy bundle image.
+#
+# Usage:
+#   update-policy-digest.sh <tasks-dir> [<policy-image>]
+#
+# Arguments:
+#   tasks-dir     - Directory containing task YAML files (searched recursively)
+#   policy-image  - Policy bundle image reference (default: quay.io/conforma/release-policy:konflux)
+
+set -euo pipefail
+
+TASKS_DIR="${1:?Usage: update-policy-digest.sh <tasks-dir> [<policy-image>]}"
+POLICY_IMAGE="${2:-quay.io/conforma/release-policy:konflux}"
+
+NEW_DIGEST=$(crane digest "$POLICY_IMAGE")
+echo "Release policy digest: ${NEW_DIGEST}"
+
+TASK_FILES=$(grep -rl 'POLICY_BUNDLE_DIGEST' "$TASKS_DIR" || true)
+if [ -z "$TASK_FILES" ]; then
+    echo "ERROR: No task files contain POLICY_BUNDLE_DIGEST in ${TASKS_DIR}"
+    exit 1
+fi
+
+UPDATED=0
+for f in $TASK_FILES; do
+    OLD_DIGEST=$(yq eval '.spec.params[] | select(.name == "POLICY_BUNDLE_DIGEST") | .default' "$f")
+    if [ -z "$OLD_DIGEST" ] || [ "$OLD_DIGEST" = "null" ]; then
+        echo "Warning: could not extract current digest from $f, skipping"
+        continue
+    fi
+    if [ "$OLD_DIGEST" = "$NEW_DIGEST" ]; then
+        echo "Already up to date in $f"
+        continue
+    fi
+    yq eval '(.spec.params[] | select(.name == "POLICY_BUNDLE_DIGEST") | .default) = "'"${NEW_DIGEST}"'"' -i "$f"
+    echo "Updated $f: ${OLD_DIGEST} → ${NEW_DIGEST}"
+    UPDATED=$((UPDATED + 1))
+done
+
+echo ""
+echo "Done. Updated ${UPDATED} file(s)."

--- a/spec/extract_all_bundle_tasks_spec.sh
+++ b/spec/extract_all_bundle_tasks_spec.sh
@@ -1,0 +1,179 @@
+Describe "extract-all-bundle-tasks.sh"
+  SCRIPT="./hack/extract-all-bundle-tasks.sh"
+
+  setup() {
+    setup_tmpdir
+    create_mock_crane
+    export CRANE_DATA="${TMPDIR}/crane"
+    export PATH="${MOCK_BIN}:${PATH}"
+  }
+
+  cleanup() {
+    cleanup_tmpdir
+  }
+
+  Before "setup"
+  After "cleanup"
+
+  Describe "extracts tasks from a bundle"
+    setup_bundle() {
+      cat > "${TMPDIR}/crane/manifest.json" <<'EOF'
+{
+  "layers": [
+    {
+      "digest": "sha256:aaa111",
+      "annotations": {
+        "dev.tekton.image.kind": "task",
+        "dev.tekton.image.name": "verify-enterprise-contract"
+      }
+    },
+    {
+      "digest": "sha256:bbb222",
+      "annotations": {
+        "dev.tekton.image.kind": "task",
+        "dev.tekton.image.name": "collect-keyless-params"
+      }
+    }
+  ]
+}
+EOF
+
+      create_blob "sha256:aaa111" "apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: verify-enterprise-contract
+  labels:
+    app.kubernetes.io/version: \"0.1\"
+spec:
+  params:
+  - name: POLICY_BUNDLE_DIGEST
+    default: \"sha256:olddigest\"
+"
+
+      create_blob "sha256:bbb222" "apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-keyless-params
+  labels:
+    app.kubernetes.io/version: \"0.2\"
+spec:
+  params:
+  - name: SOME_PARAM
+    default: value
+"
+    }
+
+    Before "setup_bundle"
+
+    It "creates catalog directory layout"
+      When run script "$SCRIPT" "quay.io/conforma/tekton-task:latest" "${TMPDIR}/output"
+      The status should be success
+      The output should include "Extracted 2 task(s)"
+      The path "${TMPDIR}/output/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml" should be file
+      The path "${TMPDIR}/output/tasks/collect-keyless-params/0.2/collect-keyless-params.yaml" should be file
+    End
+
+    It "writes valid YAML content"
+      When run script "$SCRIPT" "quay.io/conforma/tekton-task:latest" "${TMPDIR}/output"
+      The status should be success
+      The output should include "Extracted 2 task(s)"
+      The contents of file "${TMPDIR}/output/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml" should include "verify-enterprise-contract"
+      The contents of file "${TMPDIR}/output/tasks/collect-keyless-params/0.2/collect-keyless-params.yaml" should include "collect-keyless-params"
+    End
+  End
+
+  Describe "handles digest references"
+    setup_digest_ref() {
+      cat > "${TMPDIR}/crane/manifest.json" <<'EOF'
+{
+  "layers": [
+    {
+      "digest": "sha256:ccc333",
+      "annotations": {
+        "dev.tekton.image.kind": "task",
+        "dev.tekton.image.name": "my-task"
+      }
+    }
+  ]
+}
+EOF
+
+      create_blob "sha256:ccc333" "apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: my-task
+  labels:
+    app.kubernetes.io/version: \"1.0\"
+spec: {}
+"
+    }
+
+    Before "setup_digest_ref"
+
+    It "strips digest from repo for blob fetch"
+      When run script "$SCRIPT" "quay.io/conforma/tekton-task@sha256:abc123" "${TMPDIR}/output"
+      The status should be success
+      The output should include "Extracted 1 task(s)"
+    End
+  End
+
+  Describe "error cases"
+    It "fails when no arguments provided"
+      When run script "$SCRIPT"
+      The status should be failure
+      The stderr should include "Usage"
+    End
+
+    It "fails when output-dir argument is missing"
+      When run script "$SCRIPT" "quay.io/conforma/tekton-task:latest"
+      The status should be failure
+      The stderr should include "Usage"
+    End
+
+    It "fails when bundle contains no task layers"
+      cat > "${TMPDIR}/crane/manifest.json" <<'EOF'
+{
+  "layers": [
+    {
+      "digest": "sha256:notask",
+      "annotations": {
+        "dev.tekton.image.kind": "pipeline",
+        "dev.tekton.image.name": "some-pipeline"
+      }
+    }
+  ]
+}
+EOF
+      When run script "$SCRIPT" "quay.io/conforma/tekton-task:latest" "${TMPDIR}/output"
+      The status should be failure
+      The output should include "No task layers found"
+    End
+
+    It "fails when task is missing version label"
+      cat > "${TMPDIR}/crane/manifest.json" <<'EOF'
+{
+  "layers": [
+    {
+      "digest": "sha256:nover",
+      "annotations": {
+        "dev.tekton.image.kind": "task",
+        "dev.tekton.image.name": "bad-task"
+      }
+    }
+  ]
+}
+EOF
+
+      create_blob "sha256:nover" "apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: bad-task
+spec: {}
+"
+
+      When run script "$SCRIPT" "quay.io/conforma/tekton-task:latest" "${TMPDIR}/output"
+      The status should be failure
+      The output should include "missing the app.kubernetes.io/version label"
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,61 @@
+set -euo pipefail
+
+# Create a temporary directory for each test group and clean up after.
+setup_tmpdir() {
+  TMPDIR=$(mktemp -d)
+  MOCK_BIN="${TMPDIR}/bin"
+  mkdir -p "$MOCK_BIN"
+}
+
+cleanup_tmpdir() {
+  rm -rf "$TMPDIR"
+}
+
+# Create a mock crane script that dispatches on subcommand.
+# Uses files in $TMPDIR/crane/ to store mock data:
+#   manifest.json        — returned by "crane manifest"
+#   blobs/<digest>.tar.gz — returned by "crane blob repo@<digest>"
+#   digest.txt           — returned by "crane digest"
+create_mock_crane() {
+  mkdir -p "${TMPDIR}/crane/blobs"
+  cat > "${MOCK_BIN}/crane" <<'CRANE_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+CRANE_DATA="${CRANE_DATA:?CRANE_DATA not set}"
+case "${1:-}" in
+  manifest)
+    cat "${CRANE_DATA}/manifest.json"
+    ;;
+  blob)
+    ref="$2"
+    digest="${ref#*@}"
+    cat "${CRANE_DATA}/blobs/${digest}.tar.gz"
+    ;;
+  digest)
+    cat "${CRANE_DATA}/digest.txt"
+    ;;
+  auth)
+    exit 0
+    ;;
+  *)
+    echo "mock crane: unknown subcommand: $1" >&2
+    exit 1
+    ;;
+esac
+CRANE_EOF
+  chmod +x "${MOCK_BIN}/crane"
+}
+
+# Create a gzipped tar blob containing a single YAML file.
+# Usage: create_blob <digest> <yaml-content>
+create_blob() {
+  local digest="$1"
+  local yaml="$2"
+  local blob_dir="${TMPDIR}/crane/blobs"
+  local staging="${TMPDIR}/blob-staging"
+
+  mkdir -p "$blob_dir" "$staging"
+  printf '%s' "$yaml" > "${staging}/task.yaml"
+  tar -cf - -C "$staging" task.yaml | gzip > "${blob_dir}/${digest}.tar.gz"
+  rm -rf "$staging"
+}

--- a/spec/update_policy_digest_spec.sh
+++ b/spec/update_policy_digest_spec.sh
@@ -1,0 +1,160 @@
+Describe "update-policy-digest.sh"
+  SCRIPT="./hack/update-policy-digest.sh"
+  MOCK_NEW_DIGEST="sha256:newdigestnewdigestnewdigestnewdigestnewdigestnewdigestnewdigest00"
+
+  setup() {
+    setup_tmpdir
+    create_mock_crane
+    echo "$MOCK_NEW_DIGEST" > "${TMPDIR}/crane/digest.txt"
+    export CRANE_DATA="${TMPDIR}/crane"
+    export PATH="${MOCK_BIN}:${PATH}"
+  }
+
+  cleanup() {
+    cleanup_tmpdir
+  }
+
+  Before "setup"
+  After "cleanup"
+
+  create_task_yaml() {
+    local dir="$1"
+    local name="$2"
+    local digest="$3"
+    mkdir -p "$dir"
+    cat > "${dir}/${name}.yaml" <<EOF
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: ${name}
+spec:
+  params:
+  - name: POLICY_BUNDLE_DIGEST
+    default: "${digest}"
+  - name: OTHER_PARAM
+    default: unchanged
+EOF
+  }
+
+  Describe "updates digest in task files"
+    setup_tasks() {
+      create_task_yaml "${TMPDIR}/tasks/verify-ec/0.1" "verify-ec" "sha256:oldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldold0"
+    }
+
+    Before "setup_tasks"
+
+    It "replaces the old digest with the new one"
+      When run script "$SCRIPT" "${TMPDIR}/tasks"
+      The status should be success
+      The output should include "Updated"
+      The output should include "Updated 1 file(s)"
+      The contents of file "${TMPDIR}/tasks/verify-ec/0.1/verify-ec.yaml" should include "$MOCK_NEW_DIGEST"
+    End
+
+    It "does not modify other params"
+      When run script "$SCRIPT" "${TMPDIR}/tasks"
+      The status should be success
+      The output should include "Updated 1 file(s)"
+      The contents of file "${TMPDIR}/tasks/verify-ec/0.1/verify-ec.yaml" should include "unchanged"
+    End
+  End
+
+  Describe "updates multiple task files"
+    setup_multi() {
+      create_task_yaml "${TMPDIR}/tasks/task-a/0.1" "task-a" "sha256:oldaoldaoldaoldaoldaoldaoldaoldaoldaoldaoldaoldaoldaoldaoldaolda"
+      create_task_yaml "${TMPDIR}/tasks/task-b/0.1" "task-b" "sha256:oldboldboldboldboldboldboldboldboldboldboldboldboldboldboldbold0"
+    }
+
+    Before "setup_multi"
+
+    It "updates all files that contain POLICY_BUNDLE_DIGEST"
+      When run script "$SCRIPT" "${TMPDIR}/tasks"
+      The status should be success
+      The output should include "Updated 2 file(s)"
+      The contents of file "${TMPDIR}/tasks/task-a/0.1/task-a.yaml" should include "$MOCK_NEW_DIGEST"
+      The contents of file "${TMPDIR}/tasks/task-b/0.1/task-b.yaml" should include "$MOCK_NEW_DIGEST"
+    End
+  End
+
+  Describe "idempotent when already up to date"
+    setup_current() {
+      create_task_yaml "${TMPDIR}/tasks/verify-ec/0.1" "verify-ec" "$MOCK_NEW_DIGEST"
+    }
+
+    Before "setup_current"
+
+    It "reports already up to date"
+      When run script "$SCRIPT" "${TMPDIR}/tasks"
+      The status should be success
+      The output should include "Already up to date"
+      The output should include "Updated 0 file(s)"
+    End
+  End
+
+  Describe "skips files without extractable digest"
+    setup_no_param() {
+      local dir="${TMPDIR}/tasks/odd-task/0.1"
+      mkdir -p "$dir"
+      # File contains POLICY_BUNDLE_DIGEST as text but not as a yq-extractable param
+      cat > "${dir}/odd-task.yaml" <<'EOF'
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: odd-task
+spec:
+  steps:
+  - name: run
+    script: echo POLICY_BUNDLE_DIGEST
+EOF
+    }
+
+    Before "setup_no_param"
+
+    It "warns and skips"
+      When run script "$SCRIPT" "${TMPDIR}/tasks"
+      The status should be success
+      The output should include "Warning: could not extract current digest"
+      The output should include "Updated 0 file(s)"
+    End
+  End
+
+  Describe "custom policy image"
+    setup_custom() {
+      create_task_yaml "${TMPDIR}/tasks/verify-ec/0.1" "verify-ec" "sha256:oldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldold0"
+    }
+
+    Before "setup_custom"
+
+    It "accepts a custom policy image reference"
+      When run script "$SCRIPT" "${TMPDIR}/tasks" "quay.io/custom/policy:v1"
+      The status should be success
+      The output should include "Updated 1 file(s)"
+    End
+  End
+
+  Describe "error cases"
+    It "fails when no arguments provided"
+      When run script "$SCRIPT"
+      The status should be failure
+      The stderr should include "Usage"
+    End
+
+    It "fails when no task files contain POLICY_BUNDLE_DIGEST"
+      local dir="${TMPDIR}/tasks/no-digest/0.1"
+      mkdir -p "$dir"
+      cat > "${dir}/no-digest.yaml" <<'EOF'
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: no-digest
+spec:
+  params:
+  - name: SOME_OTHER_PARAM
+    default: value
+EOF
+      When run script "$SCRIPT" "${TMPDIR}/tasks"
+      The status should be failure
+      The output should include "No task files contain POLICY_BUNDLE_DIGEST"
+    End
+  End
+End


### PR DESCRIPTION
Jira: [EC-1846](https://redhat.atlassian.net/browse/EC-1846)

## Summary

- After acceptance tests and policy tagging, the `tekton-catalog-release` job now updates the `POLICY_BUNDLE_DIGEST` default in task definitions to the current `release-policy:konflux` digest
- Rebuilds the tekton-task bundle with updated tasks and pushes as `:konflux`, keeping the bundle and tekton-catalog in sync
- Adds `hack/extract-all-bundle-tasks.sh` to extract all tasks from a bundle (not just acceptance-tested ones), so `collect-keyless-params` is included

## Changes

**`tag` job**: Filters tekton-task entries from "Tag tested images by digest" since the bundle is now rebuilt by `tekton-catalog-release`.

**`tekton-catalog-release` job**:
- Depends on both `acceptance-tests` and `tag` (tolerates `tag` being skipped)
- Logs in to quay.io via `crane auth login` (compatible with `tkn bundle push`)
- Extracts all tasks from the tested bundle using the new `extract-all-bundle-tasks.sh`
- Computes the `release-policy:konflux` digest via `crane digest` and updates `POLICY_BUNDLE_DIGEST` in task definitions
- Pushes rebuilt bundle as `quay.io/conforma/tekton-task:konflux` via `tkn bundle push`
- Pushes updated tasks to `conforma/tekton-catalog` konflux branch (existing behavior)

## Test plan

- [ ] Run workflow via `workflow_dispatch` with `run_tag: true` and `run_tekton_catalog: true`
- [ ] Verify `quay.io/conforma/tekton-task:konflux` contains all 3 tasks (`verify-enterprise-contract`, `verify-conforma-konflux-ta`, `collect-keyless-params`)
- [ ] Verify `POLICY_BUNDLE_DIGEST` default in the bundle tasks matches `crane digest quay.io/conforma/release-policy:konflux`
- [ ] Verify `conforma/tekton-catalog` konflux branch has the same updated digest
- [ ] Verify `run_tag: false` + `run_tekton_catalog: true` still works (uses existing `:konflux` digest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)