### PR TITLE
Fix tekton-task-bundle and tekton-catalog skipping when run independently

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -175,7 +175,7 @@ jobs:
         path: /tmp/catalog-tasks/tasks/
 
   tekton-task-bundle:
-    if: ${{ needs.update-task-definitions.result == 'success' && inputs.run_tekton_task_bundle != false }}
+    if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && inputs.run_tekton_task_bundle != false }}
     runs-on: ubuntu-latest
     needs: [update-task-definitions]
 
@@ -212,7 +212,7 @@ jobs:
         tkn bundle push quay.io/conforma/tekton-task:konflux "${TASK_FILES[@]}"
 
   tekton-catalog:
-    if: ${{ needs.update-task-definitions.result == 'success' && inputs.run_tekton_catalog != false }}
+    if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && inputs.run_tekton_catalog != false }}
     runs-on: ubuntu-latest
     needs: [update-task-definitions]
 


### PR DESCRIPTION
## Summary
- Add `!cancelled() && !failure()` to the `if` conditions for `tekton-task-bundle` and `tekton-catalog` jobs
- Without these status functions, GitHub Actions propagates the skipped status from the `tag` job through the dependency chain via `update-task-definitions`, causing these jobs to be skipped even when their direct dependency succeeded
- Matches the pattern already used by `update-task-definitions`

## Test plan
- [ ] Run workflow with only `run_tekton_catalog` checked — verify `tekton-catalog` runs
- [ ] Run workflow with only `run_tekton_task_bundle` checked — verify `tekton-task-bundle` runs
- [ ] Run workflow with all inputs checked — verify all jobs run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)