### PR TITLE
Replace tektoncd/actions with direct tkn install

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -184,9 +184,13 @@ jobs:
       uses: imjasonh/setup-crane@v0.4
 
     - name: Install tkn
-      uses: tektoncd/actions/setup-tektoncd-cli@v1
-      with:
-        version: latest
+      run: |
+        set -euo pipefail
+        VERSION=$(gh release view --repo tektoncd/cli --json tagName -q .tagName)
+        URL="https://github.com/tektoncd/cli/releases/download/${VERSION}/tkn_${VERSION#v}_Linux_x86_64.tar.gz"
+        curl -sSL "$URL" | sudo tar -xz -C /usr/local/bin tkn
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Log in to quay.io/conforma
       env:


### PR DESCRIPTION
## Summary
- The `tektoncd/actions` repo has no version tags, so `@v1` cannot resolve, causing the `tekton-task-bundle` job to fail
- Replace with a direct install from `tektoncd/cli` releases

## Test plan
- [ ] Run workflow with `run_tekton_task_bundle` checked — verify `tkn` installs and bundle push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)