### PR TITLE
feat(EC-1987): improve changelog formatting and branding

### DIFF
--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -181,7 +181,7 @@ render_rule_diff() {
             "**\($group[0].kind)**",
             "",
             ($group[] |
-                (if .doc_url != "" then "- **[\(.title)](\(.doc_url))** — " else "- **\(.title)** — " end) +
+                (if (.doc_url // "") != "" then "- **[\(.title)](\(.doc_url))** — " else "- **\(.title)** — " end) +
                 "\(.description)<br>Effective: \(.effective_on | if . == "" then "now" else .[0:10] end) · Collections: \(.collections | join(", "))"
             )'
     fi
@@ -195,7 +195,7 @@ render_rule_diff() {
             "**\($group[0].kind)**",
             "",
             ($group[] |
-                (if .doc_url != "" then "- **[\(.title)](\(.doc_url))** — " else "- **\(.title)** — " end) +
+                (if (.doc_url // "") != "" then "- **[\(.title)](\(.doc_url))** — " else "- **\(.title)** — " end) +
                 "\(.description)<br>Collections: \(.collections | join(", "))"
             )'
     fi

--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -156,7 +156,9 @@ render_rule_diff() {
     echo "  diffing ${name}..." >&2
     local diff_json
     diff_json=$(cd "${REPO_ROOT}/hack/policy-rule-diff" && go run . \
-        -bundle -json "${image}:konflux" "${image}:latest" 2>/dev/null)
+        -bundle -json \
+        -doc-base-url "https://conforma.dev/docs/policy/packages" \
+        "${image}:konflux" "${image}:latest" 2>/dev/null)
 
     local added removed
     added=$(echo "$diff_json" | jq '.added | length')
@@ -179,7 +181,8 @@ render_rule_diff() {
             "**\($group[0].kind)**",
             "",
             ($group[] |
-                "- **\(.title)** — \(.description)<br>Effective: \(.effective_on | if . == "" then "now" else .[0:10] end) · Collections: \(.collections | join(", "))"
+                (if .doc_url != "" then "- **[\(.title)](\(.doc_url))** — " else "- **\(.title)** — " end) +
+                "\(.description)<br>Effective: \(.effective_on | if . == "" then "now" else .[0:10] end) · Collections: \(.collections | join(", "))"
             )'
     fi
 
@@ -192,7 +195,8 @@ render_rule_diff() {
             "**\($group[0].kind)**",
             "",
             ($group[] |
-                "- **\(.title)** — \(.description)<br>Collections: \(.collections | join(", "))"
+                (if .doc_url != "" then "- **[\(.title)](\(.doc_url))** — " else "- **\(.title)** — " end) +
+                "\(.description)<br>Collections: \(.collections | join(", "))"
             )'
     fi
 }
@@ -210,7 +214,9 @@ echo "Generating changelog..." >&2
 
 # --- Section 1: Image digests ---
 
-echo "# Conforma Release"
+echo "# Konflux Policy Release"
+echo ""
+echo "> Conforma policy update for Red Hat's Konflux deployment."
 echo ""
 echo "## Images"
 echo ""
@@ -272,9 +278,21 @@ echo "Running policy rule diffs..." >&2
 echo ""
 echo "## Policy Rule Changes"
 
-for image in "${POLICY_IMAGES[@]}"; do
-    render_rule_diff "$image"
-done
+# Render release-policy first (primary focus)
+render_rule_diff "${POLICY_IMAGES[0]}"
+
+# Render remaining policies in a collapsible section
+if [[ ${#POLICY_IMAGES[@]} -gt 1 ]]; then
+    echo ""
+    echo "<details>"
+    echo "<summary>Task and build policy changes</summary>"
+    echo ""
+    for image in "${POLICY_IMAGES[@]:1}"; do
+        render_rule_diff "$image"
+    done
+    echo ""
+    echo "</details>"
+fi
 
 echo "" >&2
 

--- a/hack/policy-rule-diff/main.go
+++ b/hack/policy-rule-diff/main.go
@@ -341,6 +341,7 @@ func parseRegoRules(content string) map[string]*rule {
 // ---------------------------------------------------------------------------
 
 var useColor bool
+var docBaseURL string
 
 func colorize(text, code string) string {
 	if !useColor {
@@ -547,6 +548,20 @@ type jsonRule struct {
 	Collections []string `json:"collections"`
 	File        string   `json:"file"`
 	Source      string   `json:"source"`
+	DocURL      string   `json:"doc_url,omitempty"`
+}
+
+func buildDocURL(file, pkg, shortName string) string {
+	if docBaseURL == "" || pkg == "" || shortName == "" {
+		return ""
+	}
+	parts := strings.SplitN(file, "/", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	policyType := parts[1] // "release", "pipeline", "build_task", etc.
+	return fmt.Sprintf("%s/%s_%s.html#%s__%s",
+		strings.TrimRight(docBaseURL, "/"), policyType, pkg, pkg, shortName)
 }
 
 func ruleChangeToJSON(c ruleChange) jsonRule {
@@ -566,6 +581,7 @@ func ruleChangeToJSON(c ruleChange) jsonRule {
 		Collections: collections,
 		File:        c.file,
 		Source:      c.rule.source(),
+		DocURL:      buildDocURL(c.file, c.rule.pkg, c.rule.shortName),
 	}
 }
 
@@ -937,6 +953,7 @@ func main() {
 	bundle := flag.Bool("bundle", false, "Compare two OCI bundle image references (pass as positional args)")
 	noColor := flag.Bool("no-color", false, "Disable color output")
 	jsonOut := flag.Bool("json", false, "Output structured JSON for LLM consumption")
+	docBase := flag.String("doc-base-url", "https://conforma.dev/docs/policy/packages", "Base URL for rule documentation links")
 
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, `Usage: policy-rule-diff [flags] [refs...]
@@ -956,6 +973,7 @@ Flags:`)
 	flag.Parse()
 
 	useColor = !*noColor && isTerminal()
+	docBaseURL = *docBase
 
 	// ── Direct file comparison ───────────────────────────────────────────
 	if *before != "" || *after != "" {


### PR DESCRIPTION
## Summary

- Add `doc_url` field to policy-rule-diff JSON output with `-doc-base-url` flag, linking rule names to conforma.dev documentation
- Make rule names clickable markdown links in the changelog
- Update heading to "Konflux Policy Release" with Conforma attribution
- Wrap task-policy and build-task-policy sections in collapsible `<details>` blocks

Resolves: EC-1987

## Test plan

- [x] `go build` succeeds for policy-rule-diff
- [x] `bash -n generate-changelog.sh` syntax check passes
- [ ] Run `generate-changelog.sh -` to verify formatted output
- [ ] Verify doc links resolve to correct pages on conforma.dev

🤖 Generated with [Claude Code](https://claude.ai/claude-code)