### PR TITLE
Fix konflux-policy workflow for push-triggered runs

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       release_dir:
-        description: 'Release directory containing images.json (e.g. releases/2026-06-30T14:30:00)'
+        description: 'Release date (e.g. 2026-08-11T17:36:11) — matches a directory under releases/'
         type: string
         required: true
       run_tag:
@@ -54,7 +54,9 @@ jobs:
         set -euo pipefail
 
         if [[ -n "$RELEASE_DIR" ]]; then
-          IMAGES_FILE="${RELEASE_DIR}/images.json"
+          # Normalize: accept bare date or full path
+          RELEASE_DIR="${RELEASE_DIR#releases/}"
+          IMAGES_FILE="releases/${RELEASE_DIR}/images.json"
         else
           IMAGES_FILE=$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" \
             | { grep '^releases/.*/images\.json$' || true; } | head -1)
@@ -94,7 +96,7 @@ jobs:
       run: make acceptance
 
   tag:
-    if: inputs.run_tag != false
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_tag != false }}
     runs-on: ubuntu-latest
     needs: [acceptance-tests]
 
@@ -154,7 +156,7 @@ jobs:
         done
 
   update-task-definitions:
-    if: ${{ !cancelled() && !failure() && (inputs.run_tekton_task_bundle != false || inputs.run_tekton_catalog != false) }}
+    if: ${{ !cancelled() && !failure() && (github.event_name != 'workflow_dispatch' || inputs.run_tekton_task_bundle != false || inputs.run_tekton_catalog != false) }}
     runs-on: ubuntu-latest
     needs: [acceptance-tests, tag]
 
@@ -199,7 +201,7 @@ jobs:
         path: /tmp/catalog-tasks/tasks/
 
   tekton-task-bundle:
-    if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && inputs.run_tekton_task_bundle != false }}
+    if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run_tekton_task_bundle != false) }}
     runs-on: ubuntu-latest
     needs: [update-task-definitions]
 
@@ -240,7 +242,7 @@ jobs:
         tkn bundle push quay.io/conforma/tekton-task:konflux "${TASK_FILES[@]}"
 
   tekton-catalog:
-    if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && inputs.run_tekton_catalog != false }}
+    if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run_tekton_catalog != false) }}
     runs-on: ubuntu-latest
     needs: [update-task-definitions]
 

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -134,7 +134,7 @@ jobs:
               [[ -z "$mirror" ]] && continue
               echo "Updating ${mirror}:konflux"
               skopeo copy --all --digestfile image.digest \
-                "docker://${mirror}@${digest}" "docker://${mirror}:konflux"
+                "docker://${image}@${digest}" "docker://${mirror}:konflux"
               echo "Image digest: $(cat image.digest)"
             done
           done


### PR DESCRIPTION
## Summary

  - Fix all downstream jobs (tag, update-task-definitions, tekton-task-bundle,
    tekton-catalog) being skipped on push events. On push, `inputs.run_*` is null
    which GitHub Actions treats as false, so `inputs.run_tag != false` evaluated to
    false. Added `github.event_name != 'workflow_dispatch'` guards so push triggers
    always run all jobs.
  - Fix mirror tagging copying from the mirror repo by digest — the digest only
    exists in the primary image. Now copies from primary to mirror.
  - Simplify the `release_dir` manual trigger input to accept a bare date string
    (e.g. `2026-08-11T17:36:11`) in addition to the full `releases/...` path.

https://redhat.atlassian.net/browse/EC-2100