### PR TITLE
Tag tekton-task bundle with a unique run tag to prevent orphaned digests (EC-2112)

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -231,6 +231,9 @@ jobs:
         path: /tmp/catalog-tasks/tasks/
 
     - name: Push tekton-task bundle
+      env:
+        RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
       run: |
         set -euo pipefail
 
@@ -239,7 +242,18 @@ jobs:
           TASK_FILES+=("-f" "$f")
         done < <(find /tmp/catalog-tasks/tasks -name '*.yaml' -type f)
 
-        tkn bundle push quay.io/conforma/tekton-task:konflux "${TASK_FILES[@]}"
+        # Push this run's bundle to its own unique tag first, then move
+        # :konflux to the same digest. Because :konflux is otherwise the only
+        # tag the bundle ever gets, each push moves :konflux and leaves the
+        # previous digest untagged (orphaned) in Quay. run_id + run_attempt
+        # make the per-run tag unique, so every pushed digest keeps a tag.
+        # Tagging :konflux from our own unique tag (rather than re-reading the
+        # mutable :konflux) also avoids a race where a concurrent run's push
+        # could leave this run's digest untagged.
+        persistent_tag="$(date -u +%Y-%m-%d)-${RUN_ID}-${RUN_ATTEMPT}"
+        tkn bundle push "quay.io/conforma/tekton-task:${persistent_tag}" "${TASK_FILES[@]}"
+        crane tag "quay.io/conforma/tekton-task:${persistent_tag}" konflux
+        echo "Pushed tekton-task bundle as ${persistent_tag} and updated :konflux"
 
   tekton-catalog:
     if: ${{ !cancelled() && !failure() && needs.update-task-definitions.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run_tekton_catalog != false) }}

--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -250,7 +250,11 @@ jobs:
         # Tagging :konflux from our own unique tag (rather than re-reading the
         # mutable :konflux) also avoids a race where a concurrent run's push
         # could leave this run's digest untagged.
-        persistent_tag="$(date -u +%Y-%m-%d)-${RUN_ID}-${RUN_ATTEMPT}"
+        # The run- prefix reserves a distinct namespace for these bundle tags:
+        # the repo also carries Konflux build tags (gh-*, kf-*) and cosign
+        # signatures (sha256-*), so a dedicated prefix lets the orphan cleanup
+        # (EC-2113) age out run-* tags without matching anything else.
+        persistent_tag="run-$(date -u +%Y-%m-%d)-${RUN_ID}-${RUN_ATTEMPT}"
         tkn bundle push "quay.io/conforma/tekton-task:${persistent_tag}" "${TASK_FILES[@]}"
         crane tag "quay.io/conforma/tekton-task:${persistent_tag}" konflux
         echo "Pushed tekton-task bundle as ${persistent_tag} and updated :konflux"


### PR DESCRIPTION
## Problem

The `konflux-policy.yaml` workflow pushes the tekton-task bundle to `quay.io/conforma/tekton-task:konflux` every run. Since `:konflux` is the **only** tag this bundle ever receives, each push moves the tag to a new digest and leaves the previous digest untagged (orphaned) in Quay. These accumulate — and caused a major incident.

(Other images the workflow tags — policy images and the CLI — keep their Konflux-assigned `git-*`/`kf-*` tags when `:konflux` moves, so only the tekton-task bundle is affected.)

## Change

The `Push tekton-task bundle` step now pushes to a **unique per-run tag first**, then points `:konflux` at that same digest:

```bash
persistent_tag="$(date -u +%Y-%m-%d)-${RUN_ID}-${RUN_ATTEMPT}"
tkn bundle push "quay.io/conforma/tekton-task:${persistent_tag}" "${TASK_FILES[@]}"
crane tag "quay.io/conforma/tekton-task:${persistent_tag}" konflux
```

- `run_id` + `run_attempt` make the tag unique per push, so **every pushed digest keeps a tag** and is never orphaned.
- Pushing the unique tag *before* moving `:konflux` (rather than re-reading the mutable `:konflux`) also avoids a concurrency race where an overlapping run could otherwise leave this run's digest untagged.
- `:konflux` end-state is unchanged (points at this run's fresh bundle). `crane` is already installed in the job.

## Testing

- YAML parses; shell block passes `bash -n`; tag renders as a valid OCI tag (e.g. `2026-08-14-31712345678-2`).
- Reviewed with CodeRabbit (0 findings) and a local code review (race elimination and partial-failure behavior verified).

## Follow-up

Cleanup of pre-existing orphaned digests is tracked in **EC-2113**.

Resolves EC-2112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)