### PR TITLE
Integrate golden RPM validation to acceptance tests

### DIFF
--- a/features/validate_golden.feature
+++ b/features/validate_golden.feature
@@ -1,12 +1,12 @@
-Feature: Validate Golden Container with Latest CLI and Policies
+Feature: Validate Golden Container/RPM with Latest CLI and Policies
   Validate that the latest CLI and release policies work correctly
-  against the golden container image.
+  against the golden container image and golden RPM.
 
   Background:
     Given a cluster running
     And the conforma pipeline using task bundle "quay.io/conforma/tekton-task:latest"
 
-  Scenario: Pipeline runs to completion with @redhat collection
+  Scenario: Pipeline runs to completion with golden container and @redhat collection
     Given a working namespace
     And a policy configuration with content:
       """
@@ -27,6 +27,33 @@ Feature: Validate Golden Container with Latest CLI and Policies
       """
     When the conforma pipeline is run with:
       | SNAPSHOT             | {"components": [{"containerImage": "quay.io/konflux-ci/ec-golden-image:latest"}]} |
+      | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                                        |
+      | PUBLIC_KEY           | k8s://${NAMESPACE}/public-key                                                      |
+      | STRICT               | false                                                                              |
+    Then the pipeline should succeed
+
+
+  Scenario: Pipeline runs to completion with golden RPM, @redhat and @redhat_rpms collections
+    Given a working namespace
+    And a policy configuration with content:
+      """
+      {
+        "sources": [
+          {
+            "policy": ["oci::quay.io/conforma/release-policy:latest"],
+            "data": [
+              "git::github.com/release-engineering/rhtap-ec-policy//data",
+              "oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest"
+            ],
+            "config": {
+              "include": ["@redhat","@redhat_rpms"]
+            }
+          }
+        ]
+      }
+      """
+    When the conforma pipeline is run with:
+      | SNAPSHOT             | {"components": [{"containerImage": "quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-rpm/golden-rpm:latest"}]} |
       | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                                        |
       | PUBLIC_KEY           | k8s://${NAMESPACE}/public-key                                                      |
       | STRICT               | false                                                                              |

--- a/features/validate_golden_ta.feature
+++ b/features/validate_golden_ta.feature
@@ -1,12 +1,12 @@
-Feature: Validate Golden Container with Trusted Artifacts
+Feature: Validate Golden Container/RPM with Trusted Artifacts
   Validate that the latest CLI and release policies work correctly
-  against the golden container image using the Trusted Artifacts task.
+  against the golden container image and golden RPM using the Trusted Artifacts task.
 
   Background:
     Given a cluster running
     And the conforma-ta pipeline using task bundle "quay.io/conforma/tekton-task:latest"
 
-  Scenario: Pipeline runs to completion with @redhat collection using trusted artifacts
+  Scenario: Pipeline runs to completion with golden container and @redhat collection using trusted artifacts
     Given a working namespace
     And a policy configuration with content:
       """
@@ -27,6 +27,33 @@ Feature: Validate Golden Container with Trusted Artifacts
       """
     When the conforma pipeline is run with:
       | SNAPSHOT             | {"components": [{"containerImage": "quay.io/konflux-ci/ec-golden-image:latest"}]} |
+      | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                                        |
+      | PUBLIC_KEY           | k8s://${NAMESPACE}/public-key                                                      |
+      | STRICT               | false                                                                              |
+    Then the pipeline should succeed
+
+
+  Scenario: Pipeline runs to completion with golden RPM, @redhat and @redhat_rpms collections using trusted artifacts
+    Given a working namespace
+    And a policy configuration with content:
+      """
+      {
+        "sources": [
+          {
+            "policy": ["oci::quay.io/conforma/release-policy:latest"],
+            "data": [
+              "git::github.com/release-engineering/rhtap-ec-policy//data",
+              "oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest"
+            ],
+            "config": {
+              "include": ["@redhat","@redhat_rpms"]
+            }
+          }
+        ]
+      }
+      """
+    When the conforma pipeline is run with:
+      | SNAPSHOT             | {"components": [{"containerImage": "quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-rpm/golden-rpm:latest"}]} |
       | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                                        |
       | PUBLIC_KEY           | k8s://${NAMESPACE}/public-key                                                      |
       | STRICT               | false                                                                              |


### PR DESCRIPTION
Extends the acceptance test suite to validate the golden RPM alongside the existing golden container validation.
This ensures that both container and RPM artifacts are validated against the latest CLI and release policies in CI.

Ref: https://redhat.atlassian.net/browse/EC-1747