### PR TITLE
Pin GitHub Actions to immutable SHAs in CI workflows

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -39,7 +39,7 @@ jobs:
       release-images: ${{ steps.release-images.outputs.images }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -70,18 +70,18 @@ jobs:
         echo "images=$(jq -c . "$IMAGES_FILE")" >> "$GITHUB_OUTPUT"
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version-file: acceptance/go.mod
 
     - name: Install crane
-      uses: imjasonh/setup-crane@v0.4
+      uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
     - name: Install yq
-      uses: mikefarah/yq@v4
+      uses: mikefarah/yq@c14f446382944492701b16c1ddb48bb9dbe683e3 # v4.53.6
 
     - name: Install kind
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         install_only: true
 
@@ -103,14 +103,14 @@ jobs:
     steps:
 
     - name: Log in to quay.io/enterprise-contract
-      uses: redhat-actions/podman-login@v1
+      uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
       with:
         username: ${{ secrets.BUNDLE_PUSH_USER_EC }}
         password: ${{ secrets.BUNDLE_PUSH_PASS_EC }}
         registry: quay.io/enterprise-contract
 
     - name: Log in to quay.io/conforma
-      uses: redhat-actions/podman-login@v1
+      uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
       with:
         username: ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }}
         password: ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }}
@@ -161,13 +161,17 @@ jobs:
     needs: [acceptance-tests, tag]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        # This job pushes to tekton-catalog via the App token, not this repo's
+        # GITHUB_TOKEN, so don't persist it in the checkout's git config.
+        persist-credentials: false
 
     - name: Install crane
-      uses: imjasonh/setup-crane@v0.4
+      uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
     - name: Install yq
-      uses: mikefarah/yq@v4
+      uses: mikefarah/yq@c14f446382944492701b16c1ddb48bb9dbe683e3 # v4.53.6
 
     - name: Log in to quay.io/conforma
       env:
@@ -195,7 +199,7 @@ jobs:
       run: ./hack/update-policy-digest.sh /tmp/catalog-tasks/tasks/
 
     - name: Upload task definitions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: task-definitions
         path: /tmp/catalog-tasks/tasks/
@@ -207,7 +211,7 @@ jobs:
 
     steps:
     - name: Install crane
-      uses: imjasonh/setup-crane@v0.4
+      uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
     - name: Install tkn
       run: |
@@ -225,7 +229,7 @@ jobs:
       run: crane auth login quay.io -u "$CONFORMA_USER" -p "$CONFORMA_PASS"
 
     - name: Download task definitions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: task-definitions
         path: /tmp/catalog-tasks/tasks/
@@ -266,22 +270,24 @@ jobs:
 
     steps:
     - name: Download task definitions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: task-definitions
         path: /tmp/catalog-tasks/tasks/
 
     - name: Generate token
       id: app-token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
       with:
         app-id: ${{ secrets.EC_AUTOMATION_APP_ID }}
         private-key: ${{ secrets.EC_AUTOMATION_KEY }}
         owner: conforma
         repositories: tekton-catalog
+        # Least privilege: the token only checks out and pushes to tekton-catalog.
+        permission-contents: write
 
     - name: Checkout tekton-catalog
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: conforma/tekton-catalog
         ref: konflux

--- a/.github/workflows/label-pr-size.yaml
+++ b/.github/workflows/label-pr-size.yaml
@@ -29,4 +29,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR by size
-        uses: conforma/pr-size-label-action@v1.0.0
+        uses: conforma/pr-size-label-action@8b1fcdb87ab3ef4b79f9708fedf686904375e2d3 # v1.0.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>conforma/.github//config/renovate/renovate.json"
+    "github>conforma/.github//config/renovate/renovate.json",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
`konflux-policy.yaml` and `label-pr-size.yaml` referenced third-party GitHub
Actions by mutable tags. `konflux-policy.yaml` runs with quay.io push robot
credentials and the `EC_AUTOMATION` GitHub App key, so a repointed or
compromised action tag could execute code on a credential-bearing runner.

## Changes
- Pin every third-party `uses:` in `konflux-policy.yaml` (9 actions) and
  `label-pr-size.yaml` to full 40-character commit SHAs, with the release
  version in a trailing comment. This preserves the current versions; it is not
  an upgrade.
- Enable Renovate's `helpers:pinGitHubActionDigests` so the pinned digests are
  kept current automatically.
- Scope the minted GitHub App token to `contents: write` (it only checks out and
  pushes to `tekton-catalog`), reducing the blast radius of the token.
- Drop the persisted `GITHUB_TOKEN` from the `update-task-definitions` checkout,
  which pushes via the App token and does not need this repo's token in git
  config.

`create-pr.yaml` and `scorecards.yml` were already SHA-pinned. The
`auto-merge.yaml` reusable-workflow reference (`@main` + `secrets: inherit`) is
tracked separately under EC-2051.

## Testing
- `konflux-policy.yaml` and `label-pr-size.yaml` parse as valid YAML; `renovate.json` is valid JSON.
- All SHAs resolved from the tags the workflows previously referenced.

Ref: EC-2062
